### PR TITLE
Fixed linker error for duplicate variable definition

### DIFF
--- a/src/Entity.c
+++ b/src/Entity.c
@@ -32,6 +32,7 @@
 extern "C" {
 #endif
 
+ENTITY entities[MAX_NUM_ENTITIES+1];
 
 void InitEntities()
 {

--- a/src/sample.h
+++ b/src/sample.h
@@ -192,7 +192,7 @@ TPM_RC StartAuthSessionWithParams( SESSION **session, TPMI_DH_OBJECT tpmKey, TPM
 // with add, find, and remove entries, instead of a fixed
 // length array.
 //
-ENTITY entities[MAX_NUM_ENTITIES+1];
+extern ENTITY entities[MAX_NUM_ENTITIES+1];
 
 //
 // This function calculates the session HMAC


### PR DESCRIPTION
Changed the entities to extern and defined it in Entity.c instead, otherwise there is a linker error.